### PR TITLE
Remove 'hashie' version specification

### DIFF
--- a/metaforce.gemspec
+++ b/metaforce.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'savon', '~> 1.2.0'
   s.add_dependency 'rubyzip', '~> 1.3.0'
   s.add_dependency 'activesupport', '~> 5.2.4'
-  s.add_dependency 'hashie', '~> 4.0.0'
+  s.add_dependency 'hashie'
   s.add_dependency 'thor', '~> 1.0.1'
   s.add_dependency 'nokogiri', '1.10.7'
   s.add_dependency 'listen', '~> 3.2.1'


### PR DESCRIPTION
To conflict when used with 'restforce'.

Although the version was removed, there is also a way to set the same as 'restforce'.
https://github.com/restforce/restforce/blob/master/restforce.gemspec#L33
