### PR TITLE
Implement the reuse of Restforce credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ export SALESFORCE_SECURITY_TOKEN="security token"
 client = Metaforce.new
 ```
 
+#### Use it with Restforce
+
+```ruby
+params = {...}
+# Please refer to the Restforce documentation for more information.
+# https://github.com/restforce/restforce
+restforce_client = Restforce.new(params)
+
+client = Metaforce.new({
+  restforce_client: restforce_client
+})
+```
+
 #### Asynchronous Tasks
 
 Some calls to the SOAP API's are performed asynchronously (such as deployments),

--- a/lib/metaforce-beta.rb
+++ b/lib/metaforce-beta.rb
@@ -40,17 +40,11 @@ module Metaforce
         restforce_client.authenticate!
         options = restforce_client.options
         token = options[:oauth_token]
-        org_id = token[0, token.index('!')]
+        user_info = restforce_client.user_info
         return {
           session_id: token,
-          metadata_server_url: '%s/services/Soap/m/27.0/%s' % [
-            options[:instance_url],
-            org_id
-          ],
-          server_url: '%s/services/Soap/u/27.0/%s' % [
-            options[:instance_url],
-            org_id
-          ]
+          metadata_server_url: user_info[:urls][:metadata].sub('{version}', options[:api_version]),
+          server_url: user_info[:urls][:partner].sub('{version}', options[:api_version])
         }
       end
 

--- a/lib/metaforce-beta.rb
+++ b/lib/metaforce-beta.rb
@@ -25,10 +25,36 @@ module Metaforce
     # Performs a login and retrurns the session
     def login(options={})
       options = HashWithIndifferentAccess.new(options)
+
       username       = options.fetch(:username, ENV['SALESFORCE_USERNAME'])
       password       = options.fetch(:password, ENV['SALESFORCE_PASSWORD'])
       security_token = options.fetch(:security_token, ENV['SALESFORCE_SECURITY_TOKEN'])
-      Login.new(username, password, security_token).login
+      unless username.nil? || username.empty? ||
+          password.nil? || password.empty? ||
+          security_token.nil? || security_token.empty?
+        return Login.new(username, password, security_token).login
+      end
+
+      restforce_client = options.fetch(:restforce_client, nil)
+      unless restforce_client.nil?
+        restforce_client.authenticate!
+        options = restforce_client.options
+        token = options[:oauth_token]
+        org_id = token[0, token.index('!')]
+        return {
+          session_id: token,
+          metadata_server_url: '%s/services/Soap/m/27.0/%s' % [
+            options[:instance_url],
+            org_id
+          ],
+          server_url: '%s/services/Soap/u/27.0/%s' % [
+            options[:instance_url],
+            org_id
+          ]
+        }
+      end
+
+      raise 'There are no required options.'
     end
   end
 end

--- a/lib/metaforce/login.rb
+++ b/lib/metaforce/login.rb
@@ -10,8 +10,8 @@ module Metaforce
     def login
       response = client.request(:login) do
         soap.body = {
-          :username => username,
-          :password => password
+          username: username,
+          password: password
         }
       end
       response.body[:login_response][:result]


### PR DESCRIPTION
It is often used in conjunction with Restforce.
Implement a way to leverage Restforce's credentials.
